### PR TITLE
Rename carts -> cart

### DIFF
--- a/docker-compose-cart.yml
+++ b/docker-compose-cart.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 services:
-  carts:
+  cart:
     image: weaveworksdemos/carts
     environment:
       - reschedule=on-node-failure

--- a/docker-compose-catalogue.yml
+++ b/docker-compose-catalogue.yml
@@ -3,4 +3,4 @@ services:
   catalogue:
     environment:
     - reschedule=on-node-failure
-    image: index.docker.io/weaveworksdemos/catalogue:fast-version
+    image: index.docker.io/weaveworksdemos/catalogue:slow-version

--- a/docker-compose-catalogue.yml
+++ b/docker-compose-catalogue.yml
@@ -3,4 +3,4 @@ services:
   catalogue:
     environment:
     - reschedule=on-node-failure
-    image: index.docker.io/weaveworksdemos/catalogue:slow-version
+    image: index.docker.io/weaveworksdemos/catalogue:fast-version

--- a/docker-compose-front-end.yml
+++ b/docker-compose-front-end.yml
@@ -3,6 +3,6 @@ services:
   front-end:
     environment:
     - reschedule=on-node-failure
-    image: index.docker.io/weaveworksdemos/front-end:red-buttons
+    image: index.docker.io/weaveworksdemos/front-end:blue-buttons
     ports:
     - 80:8079


### PR DESCRIPTION
Front-end is [trying to connect to `cart`](https://github.com/microservices-demo/front-end/blob/master/api/cart/index.js#L12). But we called it `carts`. This PR fixes this.

Note that `cart` is [still trying to connect to `carts-db`](https://github.com/microservices-demo/carts/blob/master/src/main/resources/application.properties#L2), so I didn't rename that.

Thanks @vlal for digging up the references!